### PR TITLE
Try/Catch around accessing "cards" directory when said directory may not actually exist

### DIFF
--- a/util/devutil.js
+++ b/util/devutil.js
@@ -56,11 +56,15 @@ function    inquireAction(){
 function installPeerAdminCard(){
 
     var index = 1;
-    var composerDir = os.homedir()+"/.composer"
+    var composerDir = os.homedir()+"/.composer";
     if (fs.existsSync(composerDir)) {
-        fs.readdirSync(composerDir+'/cards').forEach(file => {
-            console.log(chalk.green("Existing card ("+index+") "+file)); index++;
-        })
+        try {
+            fs.readdirSync(composerDir+'/cards').forEach(file => {
+                console.log(chalk.green("Existing card ("+index+") "+file)); index++;
+            });
+        } catch (err) {
+            console.log("No existing cards directory within " + composerDir);
+        }
     } else {
         console.log(chalk.red("No cards found!!"));
         if(!fs.existsSync(os.homedir()+"./composer")){


### PR DESCRIPTION
Upon running:
```
node devutil.js
```
and selecting "1 - Install Peer Admin Card" an error is encountered if the directory "cards" does not exist within <home directory>/.composer

a simply fix i.e. without altering too much code, is to just include a try/catch around the offending code.